### PR TITLE
Send address, phone, and email

### DIFF
--- a/cardconnect/src/Message/AuthorizeRequest.php
+++ b/cardconnect/src/Message/AuthorizeRequest.php
@@ -18,12 +18,14 @@ class AuthorizeRequest extends AbstractRequest
     		'currency'  => $this->getCurrency(),
     		'orderid'   => $this->getTransactionId(),
     		'name'      => $card->getName(),
-    		'street'    => $card->getBillingAddress1(),
+    		'address'   => $card->getBillingAddress1(),
     		'city'      => $card->getBillingCity(),
     		'region'    => $card->getBillingState(),
     		'country'   => $card->getBillingCountry(),
     		'postal'    => $card->getBillingPostcode(),
-    		'tokenize'  => "Y",
+    		'phone'     => $card->getBillingPhone(),
+    		'email'     => $card->getEmail(),
+    		'tokenize'  => "Y"
     	);
         return $data;
     }

--- a/cardconnect/src/Message/AuthorizeRequest.php
+++ b/cardconnect/src/Message/AuthorizeRequest.php
@@ -25,6 +25,7 @@ class AuthorizeRequest extends AbstractRequest
     		'postal'    => $card->getBillingPostcode(),
     		'phone'     => $card->getBillingPhone(),
     		'email'     => $card->getEmail(),
+    		'ecomind'   => "E",
     		'tokenize'  => "Y"
     	);
         return $data;

--- a/cardconnect/src/Message/PurchaseRequest.php
+++ b/cardconnect/src/Message/PurchaseRequest.php
@@ -18,12 +18,14 @@ class PurchaseRequest extends AbstractRequest
     		'currency'  => $this->getCurrency(),
     		'orderid'   => $this->getTransactionId(),
     		'name'      => $card->getName(),
-    		'street'    => $card->getBillingAddress1(),
+    		'address'   => $card->getBillingAddress1(),
     		'city'      => $card->getBillingCity(),
     		'region'    => $card->getBillingState(),
     		'country'   => $card->getBillingCountry(),
     		'postal'    => $card->getBillingPostcode(),
-            'retref'    => $this->getTransactionReference(),
+    		'phone'     => $card->getBillingPhone(),
+    		'email'     => $card->getEmail(),
+    		'retref'    => $this->getTransactionReference(),
     		'tokenize'  => "Y",
     		'capture'   => "Y"
     	);

--- a/cardconnect/src/Message/PurchaseRequest.php
+++ b/cardconnect/src/Message/PurchaseRequest.php
@@ -26,6 +26,7 @@ class PurchaseRequest extends AbstractRequest
     		'phone'     => $card->getBillingPhone(),
     		'email'     => $card->getEmail(),
     		'retref'    => $this->getTransactionReference(),
+    		'ecomind'   => "E",
     		'tokenize'  => "Y",
     		'capture'   => "Y"
     	);


### PR DESCRIPTION
In order for address to be sent for AVS, the field name needs to be `address` instead of `street`. Also added the ability to send billing phone and email. Thanks for your work on this plugin!