### PR TITLE
Remove/change logging

### DIFF
--- a/cardconnect/src/Message/CaptureRequest.php
+++ b/cardconnect/src/Message/CaptureRequest.php
@@ -13,9 +13,6 @@ class CaptureRequest extends AbstractRequest
     		'currency'  => $this->getCurrency(),
     		'retref'   => $this->getTransactionReference()
     	);
-
-        error_log(print_r($this->getEndpoint(), TRUE)); 
-        error_log(print_r($data, TRUE)); 
         
         return $data;
     }


### PR DESCRIPTION
Looks like those lines may have been put there for testing and I'm wondering if they can be removed completely. They are outputting data every time a transaction is captured and resulting in some huge log files. Or if logging is useful there it could be set up with Craft's plugin log method so that it would only output data for development environments.